### PR TITLE
fix: Ikiryou description length for small mobile screen

### DIFF
--- a/src/data/squad.json
+++ b/src/data/squad.json
@@ -231,7 +231,7 @@
     "name": "Ikiryou",
     "position": "Engineering Manager",
     "image": "/img/pfp/Ikiryou.png",
-    "description": "- Jack of all trades.\n- Worked in Web2 for almost 2 decades for the hospitality industry.\n- Has too many hobbies ranging from gaming to leathercrafting.\n\nFun fact: Watched the whole Stargate and Star Trek universes more than 3 times each."
+    "description": "- Jack of all trades.\n- Nearly 20 years in Web2, working in the hospitality industry.\n- Has too many hobbies, from gaming to leathercrafting.\n\nFun fact: Had watched Stargate and Star Trek universes over 3 times each."
   },
   {
     "name": "Jahabeebs",


### PR DESCRIPTION
[[Mobile] Ikiryou's description is not completely displayed](https://linear.app/defi-wonderland/issue/PRIUI-284/[mobile]-ikiryous-description-is-not-completely-displayed)
closes PRIUI-284